### PR TITLE
refactor: align backend deps and harden tournament tests

### DIFF
--- a/backend/app/controllers/health_controller.py
+++ b/backend/app/controllers/health_controller.py
@@ -1,12 +1,5 @@
-from litestar import Controller, get, Response, status_codes
-from litestar.di import Provide
+from litestar import Controller, Response, get, status_codes
 from app.services.health_service import HealthService
-
-# Dependency provider
-
-def provide_health_service() -> HealthService:
-    from app.repositories.health_repository import HealthRepository
-    return HealthService(HealthRepository())
 
 class HealthController(Controller):
     path = "/health"
@@ -15,9 +8,9 @@ class HealthController(Controller):
     async def health_check(self) -> dict:
         return {"status": "healthy", "service": "ttt-backend", "message": "Service is running"}
 
-    @get("/ready", dependencies={"service": Provide(provide_health_service, sync_to_thread=False)})
-    async def readiness_check(self, service: HealthService) -> Response:
-        db_status = await service.check_db_ready()
+    @get("/ready")
+    async def readiness_check(self, health_service: HealthService) -> Response:
+        db_status = await health_service.check_db_ready()
         if db_status is True:
             return Response(
                 content={

--- a/backend/app/controllers/leaderboard_controller.py
+++ b/backend/app/controllers/leaderboard_controller.py
@@ -1,28 +1,19 @@
 from litestar import Controller, get
-from litestar.di import Provide
-from sqlalchemy.orm import Session
-from app.dependencies import provide_db_session
+
 from app.services.leaderboard_service import LeaderboardService
 import app.models as models
-
-# Dependency provider
-
-def provide_leaderboard_service(
-    db: Session = Provide(provide_db_session),
-) -> LeaderboardService:
-    from app.repositories.leaderboard_repository import LeaderboardRepository
-    return LeaderboardService(LeaderboardRepository(db))
 
 class LeaderboardController(Controller):
     path = "/leaderboard"
 
-    @get("/", dependencies={"service": Provide(provide_leaderboard_service, sync_to_thread=False)})
-    async def leaderboard(self, service: LeaderboardService) -> list[models.read.Player]:
-        return service.get_leaderboard()
+    @get("/")
+    async def leaderboard(self, leaderboard_service: LeaderboardService) -> list[models.read.Player]:
+        return leaderboard_service.get_leaderboard()
 
     @get(
         "/tournament/{tournament_id:str}",
-        dependencies={"service": Provide(provide_leaderboard_service, sync_to_thread=False)},
     )
-    async def tournament_leaderboard(self, service: LeaderboardService, tournament_id: str) -> list[models.read.Player]:
-        return service.get_tournament_leaderboard(tournament_id)
+    async def tournament_leaderboard(
+        self, leaderboard_service: LeaderboardService, tournament_id: str
+    ) -> list[models.read.Player]:
+        return leaderboard_service.get_tournament_leaderboard(tournament_id)

--- a/backend/app/controllers/score_controller.py
+++ b/backend/app/controllers/score_controller.py
@@ -1,21 +1,11 @@
-from litestar import Controller, post, Request
-from litestar.di import Provide
-from sqlalchemy.orm import Session
-from app.dependencies import provide_db_session
+from litestar import Controller, Request, post
+
 from app.services.score_service import ScoreService
-
-# Dependency provider
-
-def provide_score_service(
-    db: Session = Provide(provide_db_session),
-) -> ScoreService:
-    from app.repositories.score_repository import ScoreRepository
-    return ScoreService(ScoreRepository(db))
 
 class ScoreController(Controller):
     path = "/score"
 
-    @post("/", dependencies={"service": Provide(provide_score_service, sync_to_thread=False)})
-    async def update_score(self, request: Request, service: ScoreService) -> dict:
+    @post("/")
+    async def update_score(self, request: Request, score_service: ScoreService) -> dict:
         form_data = await request.form()
-        return await service.update_score(form_data)
+        return await score_service.update_score(form_data)

--- a/backend/app/controllers/tournament_controller.py
+++ b/backend/app/controllers/tournament_controller.py
@@ -1,81 +1,69 @@
 from litestar import Controller, get, post, status_codes
-from litestar.di import Provide
-from sqlalchemy.orm import Session
-from app.dependencies import provide_db_session
-from app.services.tournament_service import TournamentService
+
 from app.services.player_service import PlayerService
+from app.services.tournament_service import TournamentService
 import app.models as models
-
-# Dependency providers
-
-def provide_tournament_service(
-    db: Session = Provide(provide_db_session),
-) -> TournamentService:
-    from app.repositories.tournament_repository import TournamentRepository
-    return TournamentService(TournamentRepository(db))
-
-def provide_player_service(
-    db: Session = Provide(provide_db_session),
-) -> PlayerService:
-    from app.repositories.player_repository import PlayerRepository
-    return PlayerService(PlayerRepository(db))
 
 class TournamentController(Controller):
     path = "/tournament"
 
     # Tournament endpoints
-    @get("/", dependencies={"service": Provide(provide_tournament_service, sync_to_thread=False)})
-    async def list_tournaments(self, service: TournamentService) -> list[models.read.Tournament]:
-        return service.list_tournaments()
+    @get("/")
+    async def list_tournaments(self, tournament_service: TournamentService) -> list[models.read.Tournament]:
+        return tournament_service.list_tournaments()
 
-    @get("/{tournament_id:str}", dependencies={"service": Provide(provide_tournament_service, sync_to_thread=False)})
-    async def get_tournament(self, service: TournamentService, tournament_id: str) -> models.read.Tournament:
-        return service.get_tournament(tournament_id)
+    @get("/{tournament_id:str}")
+    async def get_tournament(
+        self, tournament_service: TournamentService, tournament_id: str
+    ) -> models.read.Tournament:
+        return tournament_service.get_tournament(tournament_id)
 
     @post(
         "/",
-        dependencies={"service": Provide(provide_tournament_service, sync_to_thread=False)},
         status_code=status_codes.HTTP_201_CREATED,
     )
-    async def create_tournament(self, service: TournamentService, data: models.create.Tournament) -> models.read.Tournament:
-        return service.create_tournament(data)
+    async def create_tournament(
+        self, tournament_service: TournamentService, data: models.create.Tournament
+    ) -> models.read.Tournament:
+        return tournament_service.create_tournament(data)
 
     @post(
         "/{tournament_id:str}/delete",
-        dependencies={"service": Provide(provide_tournament_service, sync_to_thread=False)},
         status_code=status_codes.HTTP_200_OK,
     )
-    async def delete_tournament(self, service: TournamentService, tournament_id: str) -> dict:
-        return service.delete_tournament(tournament_id)
+    async def delete_tournament(self, tournament_service: TournamentService, tournament_id: str) -> dict:
+        return tournament_service.delete_tournament(tournament_id)
 
     @post(
         "/{tournament_id:str}/reset",
-        dependencies={"service": Provide(provide_tournament_service, sync_to_thread=False)},
         status_code=status_codes.HTTP_200_OK,
     )
-    async def reset_tournament(self, service: TournamentService, tournament_id: str) -> models.read.Tournament:
-        return service.reset_tournament(tournament_id)
+    async def reset_tournament(
+        self, tournament_service: TournamentService, tournament_id: str
+    ) -> models.read.Tournament:
+        return tournament_service.reset_tournament(tournament_id)
 
     @post(
         "/{tournament_id:str}/initialize",
-        dependencies={"service": Provide(provide_tournament_service, sync_to_thread=False)},
         status_code=status_codes.HTTP_200_OK,
     )
-    async def initialize_tournament(self, service: TournamentService, tournament_id: str) -> models.read.Tournament:
-        return service.initialize_tournament(tournament_id)
+    async def initialize_tournament(
+        self, tournament_service: TournamentService, tournament_id: str
+    ) -> models.read.Tournament:
+        return tournament_service.initialize_tournament(tournament_id)
 
     # Player endpoints
     @post(
         "/{tournament_id:str}/register",
-        dependencies={"player_service": Provide(provide_player_service, sync_to_thread=False)},
         status_code=status_codes.HTTP_201_CREATED,
     )
-    async def register_player(self, player_service: PlayerService, tournament_id: str, data: models.create.Player) -> models.read.Player:
+    async def register_player(
+        self, player_service: PlayerService, tournament_id: str, data: models.create.Player
+    ) -> models.read.Player:
         return player_service.register_player(tournament_id, data)
 
     @post(
         "/{tournament_id:str}/remove-player/{player_id:str}",
-        dependencies={"player_service": Provide(provide_player_service, sync_to_thread=False)},
         status_code=status_codes.HTTP_200_OK,
     )
     async def remove_player(self, player_service: PlayerService, tournament_id: str, player_id: str) -> dict:

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,86 +1,80 @@
 from collections.abc import Generator
 
 from litestar.di import Provide
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
-from app.services.db import get_db_session
-from app.repositories.tournament_repository import TournamentRepository
-from app.repositories.player_repository import PlayerRepository
-from app.services.tournament_service import TournamentService
-from app.services.player_service import PlayerService
-from app.repositories.score_repository import ScoreRepository
-from app.services.score_service import ScoreService
-from app.repositories.leaderboard_repository import LeaderboardRepository
-from app.services.leaderboard_service import LeaderboardService
 from app.repositories.health_repository import HealthRepository
+from app.repositories.leaderboard_repository import LeaderboardRepository
+from app.repositories.player_repository import PlayerRepository
+from app.repositories.score_repository import ScoreRepository
+from app.repositories.tournament_repository import TournamentRepository
+from app.services.db import db_instance, get_db_session
 from app.services.health_service import HealthService
+from app.services.leaderboard_service import LeaderboardService
+from app.services.player_service import PlayerService
+from app.services.score_service import ScoreService
+from app.services.tournament_service import TournamentService
 
-# Dependency providers
 
-def provide_health_repository() -> HealthRepository:
-    return HealthRepository()
+def provide_session_factory() -> sessionmaker:
+    return db_instance.session_local
 
-def provide_health_service(
-    repo: HealthRepository = Provide(provide_health_repository, sync_to_thread=False),
-) -> HealthService:
-    return HealthService(repo)
+
+def provide_health_repository(session_factory: sessionmaker) -> HealthRepository:
+    return HealthRepository(session_factory)
+
+
+def provide_health_service(health_repository: HealthRepository) -> HealthService:
+    return HealthService(health_repository)
+
 
 def provide_db_session() -> Generator[Session, None, None]:
     yield from get_db_session()
 
 
-def provide_tournament_repository(
-    db: Session = Provide(provide_db_session),
-) -> TournamentRepository:
+def provide_tournament_repository(db: Session) -> TournamentRepository:
     return TournamentRepository(db)
 
-def provide_player_repository(
-    db: Session = Provide(provide_db_session),
-) -> PlayerRepository:
+
+def provide_player_repository(db: Session) -> PlayerRepository:
     return PlayerRepository(db)
 
-def provide_tournament_service(
-    repo: TournamentRepository = Provide(provide_tournament_repository, sync_to_thread=False),
-) -> TournamentService:
-    return TournamentService(repo)
 
-def provide_player_service(
-    repo: PlayerRepository = Provide(provide_player_repository, sync_to_thread=False),
-) -> PlayerService:
-    return PlayerService(repo)
+def provide_tournament_service(tournament_repository: TournamentRepository) -> TournamentService:
+    return TournamentService(tournament_repository)
 
-def provide_score_repository(
-    db: Session = Provide(provide_db_session),
-) -> ScoreRepository:
+
+def provide_player_service(player_repository: PlayerRepository) -> PlayerService:
+    return PlayerService(player_repository)
+
+
+def provide_score_repository(db: Session) -> ScoreRepository:
     return ScoreRepository(db)
 
-def provide_score_service(
-    repo: ScoreRepository = Provide(provide_score_repository, sync_to_thread=False),
-) -> ScoreService:
-    return ScoreService(repo)
 
-def provide_leaderboard_repository(
-    db: Session = Provide(provide_db_session),
-) -> LeaderboardRepository:
+def provide_score_service(score_repository: ScoreRepository) -> ScoreService:
+    return ScoreService(score_repository)
+
+
+def provide_leaderboard_repository(db: Session) -> LeaderboardRepository:
     return LeaderboardRepository(db)
 
-def provide_leaderboard_service(
-    repo: LeaderboardRepository = Provide(provide_leaderboard_repository, sync_to_thread=False),
-) -> LeaderboardService:
-    return LeaderboardService(repo)
 
-# Collect all providers in a single dict for Litestar
+def provide_leaderboard_service(leaderboard_repository: LeaderboardRepository) -> LeaderboardService:
+    return LeaderboardService(leaderboard_repository)
+
 
 dependencies = {
-    "db": Provide(provide_db_session),
-    "tournament_repository": Provide(provide_tournament_repository, sync_to_thread=False),
-    "player_repository": Provide(provide_player_repository, sync_to_thread=False),
-    "score_repository": Provide(provide_score_repository, sync_to_thread=False),
-    "leaderboard_repository": Provide(provide_leaderboard_repository, sync_to_thread=False),
-    "health_repository": Provide(provide_health_repository, sync_to_thread=False),
-    "tournament_service": Provide(provide_tournament_service, sync_to_thread=False),
-    "player_service": Provide(provide_player_service, sync_to_thread=False),
-    "score_service": Provide(provide_score_service, sync_to_thread=False),
-    "leaderboard_service": Provide(provide_leaderboard_service, sync_to_thread=False),
-    "health_service": Provide(provide_health_service, sync_to_thread=False),
+    "session_factory": Provide(provide_session_factory, sync_to_thread=True),
+    "health_repository": Provide(provide_health_repository, sync_to_thread=True),
+    "health_service": Provide(provide_health_service, sync_to_thread=True),
+    "db": Provide(provide_db_session, sync_to_thread=True),
+    "tournament_repository": Provide(provide_tournament_repository, sync_to_thread=True),
+    "player_repository": Provide(provide_player_repository, sync_to_thread=True),
+    "score_repository": Provide(provide_score_repository, sync_to_thread=True),
+    "leaderboard_repository": Provide(provide_leaderboard_repository, sync_to_thread=True),
+    "tournament_service": Provide(provide_tournament_service, sync_to_thread=True),
+    "player_service": Provide(provide_player_service, sync_to_thread=True),
+    "score_service": Provide(provide_score_service, sync_to_thread=True),
+    "leaderboard_service": Provide(provide_leaderboard_service, sync_to_thread=True),
 }

--- a/backend/app/repositories/health_repository.py
+++ b/backend/app/repositories/health_repository.py
@@ -1,21 +1,15 @@
-import os
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
+from app.services.db import db_instance
+
+
 class HealthRepository:
-    def check_db(self, database_url=None):
-        database_url = database_url or os.getenv("DATABASE_URL", "postgresql+psycopg2://user:user@db:5432/ttt")
-        engine = create_engine(
-            database_url,
-            pool_timeout=2,
-            pool_recycle=30,
-            connect_args={"connect_timeout": 3},
-        )
-        Session = sessionmaker(bind=engine)
-        session = Session()
-        try:
-            result = session.execute(text("SELECT 1")).fetchone()
-            return result is not None
-        finally:
-            session.close()
-            engine.dispose()
+    def __init__(self, session_factory: sessionmaker | None = None) -> None:
+        self._session_factory = session_factory or db_instance.session_local
+
+    def check_db(self) -> bool:
+        session_factory = self._session_factory
+        with session_factory() as session:
+            result = session.execute(text("SELECT 1")).scalar()
+            return bool(result)

--- a/backend/app/repositories/leaderboard_repository.py
+++ b/backend/app/repositories/leaderboard_repository.py
@@ -11,11 +11,12 @@ class LeaderboardRepository:
             self.db.query(
                 orm.Player.id,
                 orm.Player.name,
+                orm.Player.email,
                 func.coalesce(func.sum(orm.Team.score), 0).label("cumulative_score"),
             )
             .join(orm.player_team_association, orm.Player.id == orm.player_team_association.c.player_id)
             .join(orm.Team, orm.player_team_association.c.team_id == orm.Team.id)
-            .group_by(orm.Player.id, orm.Player.name)
+            .group_by(orm.Player.id, orm.Player.name, orm.Player.email)
             .order_by(func.sum(orm.Team.score).desc())
             .all()
         )

--- a/backend/app/repositories/player_repository.py
+++ b/backend/app/repositories/player_repository.py
@@ -15,20 +15,23 @@ class PlayerRepository:
         tournament = self.db.query(orm.Tournament).filter(orm.Tournament.id == tournament_id).first()
         if not tournament:
             raise Exception("Tournament not found")
-        existing_player = self.get_by_email(player_data.email)
-        if existing_player:
-            if existing_player in tournament.registered_players:
-                raise Exception("Player already registered for this tournament")
-            tournament.registered_players.append(existing_player)
-        else:
-            player = orm.Player(name=player_data.name, email=player_data.email)
-            self.db.add(player)
+
+        try:
+            player = self.get_by_email(player_data.email)
+            if player:
+                if player in tournament.registered_players:
+                    raise Exception("Player already registered for this tournament")
+            else:
+                player = orm.Player(name=player_data.name, email=player_data.email)
+                self.db.add(player)
+
+            tournament.registered_players.append(player)
             self.db.commit()
             self.db.refresh(player)
-            tournament.registered_players.append(player)
-            existing_player = player
-        self.db.commit()
-        return existing_player
+            return player
+        except Exception:
+            self.db.rollback()
+            raise
 
     def remove_from_tournament(self, tournament_id: str, player_id: str):
         tournament = self.db.query(orm.Tournament).filter(orm.Tournament.id == tournament_id).first()

--- a/backend/app/services/utils.py
+++ b/backend/app/services/utils.py
@@ -1,7 +1,11 @@
+import logging
 import numpy as np
 from sqlalchemy.orm import Session
 
 from app.schemas.orm import Match, Round, Team, Tournament
+
+
+logger = logging.getLogger(__name__)
 
 
 def initialize_tournament_rounds(db_session: Session, tournament_id: str):
@@ -25,52 +29,50 @@ def initialize_tournament_rounds(db_session: Session, tournament_id: str):
     # Each match needs 4 players (2v2), so matches_per_round = players // 4
     matches_per_round = max(1, len(players) // 4)
 
-    print(f"Initializing tournament '{tournament.name}' with {len(players)} players...")
-    print(f"Creating {tournament.rounds_count} rounds with {matches_per_round} matches each")
+    logger.info(
+        "Initializing tournament '%s' with %s players (%s rounds, %s matches each)",
+        tournament.name,
+        len(players),
+        tournament.rounds_count,
+        matches_per_round,
+    )
 
-    # Create rounds and matches
-    for round_number in range(1, tournament.rounds_count + 1):
-        round_obj = Round(round_number=round_number, tournament_id=tournament.id)
-        db_session.add(round_obj)
-        db_session.commit()
+    with db_session.begin():
+        for round_number in range(1, tournament.rounds_count + 1):
+            round_obj = Round(round_number=round_number, tournament_id=tournament.id)
+            db_session.add(round_obj)
 
-        # Shuffle players for this round
-        round_players = players.copy()
-        np.random.shuffle(round_players)
+            round_players = players.copy()
+            np.random.shuffle(round_players)
 
-        # Create matches for this round
-        for match_idx in range(matches_per_round):
-            match = Match(round_id=round_obj.id)
-            db_session.add(match)
-            db_session.commit()
+            for match_idx in range(matches_per_round):
+                match = Match(round_id=round_obj.id)
+                db_session.add(match)
 
-            # Create two teams with 0 scores
-            team1 = Team(match_id=match.id, score=0)
-            team2 = Team(match_id=match.id, score=0)
+                team1 = Team(match_id=match.id, score=0)
+                team2 = Team(match_id=match.id, score=0)
 
-            # Assign players to teams (4 players per match: 2 per team)
-            start_idx = match_idx * 4
-            if start_idx + 3 < len(round_players):
-                team1.players.extend(round_players[start_idx : start_idx + 2])
-                team2.players.extend(round_players[start_idx + 2 : start_idx + 4])
-            else:
-                # If not enough players, cycle through available players
-                available_players = (
-                    round_players[start_idx:] + round_players[: max(0, 4 - (len(round_players) - start_idx))]
-                )
-                if len(available_players) >= 4:
-                    team1.players.extend(available_players[:2])
-                    team2.players.extend(available_players[2:4])
+                start_idx = match_idx * 4
+                if start_idx + 3 < len(round_players):
+                    team1.players.extend(round_players[start_idx : start_idx + 2])
+                    team2.players.extend(round_players[start_idx + 2 : start_idx + 4])
                 else:
-                    # Fallback: use first 4 players if we somehow don't have enough
-                    team1.players.extend(round_players[:2])
-                    team2.players.extend(round_players[2:4] if len(round_players) >= 4 else round_players[:2])
+                    available_players = (
+                        round_players[start_idx:]
+                        + round_players[: max(0, 4 - (len(round_players) - start_idx))]
+                    )
+                    if len(available_players) >= 4:
+                        team1.players.extend(available_players[:2])
+                        team2.players.extend(available_players[2:4])
+                    else:
+                        team1.players.extend(round_players[:2])
+                        team2.players.extend(
+                            round_players[2:4] if len(round_players) >= 4 else round_players[:2]
+                        )
 
-            db_session.add_all([team1, team2])
+                db_session.add_all([team1, team2])
 
-        db_session.commit()
-
-    print(f"Tournament '{tournament.name}' initialized successfully!")
+    logger.info("Tournament '%s' initialized successfully", tournament.name)
     return tournament
 
 
@@ -86,9 +88,8 @@ def reset_tournament_rounds(db_session: Session, tournament_id: str):
     if not tournament.rounds:
         raise ValueError("Tournament has no rounds to reset")
 
-    print(f"Resetting tournament '{tournament.name}'...")
+    logger.info("Resetting tournament '%s'", tournament.name)
 
-    # Count what we're going to delete for logging
     rounds_deleted = 0
     matches_deleted = 0
     teams_deleted = 0
@@ -99,17 +100,17 @@ def reset_tournament_rounds(db_session: Session, tournament_id: str):
             matches_deleted += 1
         rounds_deleted += 1
 
-    # Delete using ORM relationships to handle cascading properly
-    # First, clear the rounds from the tournament (this will cascade delete matches and teams)
-    tournament.rounds.clear()
+    with db_session.begin():
+        tournament.rounds.clear()
+        tournament.status = "pending"
 
-    # Reset tournament status to pending
-    tournament.status = "pending"
-
-    db_session.commit()
-
-    print(f"Tournament '{tournament.name}' reset successfully!")
-    print(f"Removed: {rounds_deleted} rounds, {matches_deleted} matches, {teams_deleted} teams")
-    print(f"Preserved: Tournament details and {len(tournament.registered_players)} registered players")
+    logger.info(
+        "Tournament '%s' reset successfully. Removed %s rounds, %s matches, %s teams; preserved %s players",
+        tournament.name,
+        rounds_deleted,
+        matches_deleted,
+        teams_deleted,
+        len(tournament.registered_players),
+    )
 
     return tournament

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ import random
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 import app.models as models
 import app.schemas.orm as orm
@@ -40,8 +41,15 @@ def player_names():
 
 @pytest.fixture(scope="session")
 def engine():
-    return create_engine("sqlite:///:memory:", echo=True)
+    engine = create_engine(
+        "sqlite://",
+        echo=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     # return create_engine("sqlite:///ttt.db")
+    yield engine
+    engine.dispose()
 
 
 @pytest.fixture(scope="session")
@@ -55,7 +63,7 @@ def tables(engine):
 def db_session(engine, tables):
     """Returns an sqlalchemy session, and after the test tears down everything properly."""
     connection = engine.connect()
-    # transaction = connection.begin()
+    transaction = connection.begin()
 
     # Bind an individual Session to the connection
     Session = sessionmaker(bind=connection)
@@ -64,8 +72,8 @@ def db_session(engine, tables):
     yield session
 
     session.close()
-    # transaction.rollback()
-    # connection.close()
+    transaction.rollback()
+    connection.close()
 
 
 @pytest.fixture
@@ -73,7 +81,7 @@ def tournament(db_session, player_names):
     """Create a full tournament with 24 players, following the correct hierarchy."""
 
     # Step 1: Create the Tournament
-    tournament_data = models.create.Tournament(start_date="2025-02-15", rounds_count=10)
+    tournament_data = models.create.Tournament(name="Fixture Tournament", start_date="2025-02-15", rounds_count=10)
     tournament_model = orm.Tournament(**tournament_data.model_dump())
 
     db_session.add(tournament_model)
@@ -133,11 +141,11 @@ def tournament(db_session, player_names):
         player1_name = next(player_iter, f"Player_{len(teams)}")
         player2_name = next(player_iter, f"Player_{len(teams) + 1}")
 
-        player1_data = models.create.Player(name=player1_name)
+        player1_data = models.create.Player(name=player1_name, email=f"{player1_name.lower()}@example.com")
         player1_model = orm.Player(**player1_data.model_dump())
         player1_model.teams.append(team_model)
 
-        player2_data = models.create.Player(name=player2_name)
+        player2_data = models.create.Player(name=player2_name, email=f"{player2_name.lower()}@example.com")
         player2_model = orm.Player(**player2_data.model_dump())
         player2_model.teams.append(team_model)
 

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -5,7 +5,7 @@ from app.schemas.orm import Match, Player, Round, Team, Tournament
 
 
 def test_create_tournament(db_session):
-    tournament = Tournament(start_date=date.today())
+    tournament = Tournament(name="Test Tournament", start_date=date.today())
     db_session.add(tournament)
     db_session.commit()
 
@@ -13,7 +13,7 @@ def test_create_tournament(db_session):
 
 
 def test_create_round(db_session):
-    tournament = Tournament(start_date=date.today())
+    tournament = Tournament(name="Round Test", start_date=date.today())
     db_session.add(tournament)
     db_session.commit()
 
@@ -26,7 +26,7 @@ def test_create_round(db_session):
 
 
 def test_create_match(db_session):
-    tournament = Tournament(start_date=date.today())
+    tournament = Tournament(name="Match Test", start_date=date.today())
     db_session.add(tournament)
     db_session.commit()
 
@@ -64,8 +64,8 @@ def test_create_players_and_assign_to_team(db_session):
     db_session.add(team)
     db_session.commit()
 
-    player1 = Player(name="Alice", cumulative_score=0)
-    player2 = Player(name="Bob", cumulative_score=0)
+    player1 = Player(name="Alice", email="alice@example.com", cumulative_score=0)
+    player2 = Player(name="Bob", email="bob@example.com", cumulative_score=0)
 
     team.players.append(player1)
     team.players.append(player2)
@@ -86,8 +86,8 @@ def test_players_inherit_team_score(db_session):
     db_session.add(team)
     db_session.commit()
 
-    player1 = Player(name="Charlie")
-    player2 = Player(name="Dana")
+    player1 = Player(name="Charlie", email="charlie@example.com")
+    player2 = Player(name="Dana", email="dana@example.com")
     team.players.append(player1)
     team.players.append(player2)
     db_session.commit()
@@ -102,11 +102,11 @@ def test_players_inherit_team_score(db_session):
 
 def test_create_full_tournament_structure(db_session, player_names):
     # Step 1: Create tournament
-    tournament = Tournament(start_date=date.today())
+    tournament = Tournament(name="Full Tournament", start_date=date.today())
     db_session.add(tournament)
     db_session.commit()
 
-    players = [Player(name=name, cumulative_score=0) for name in player_names]
+    players = [Player(name=name, email=f"{name.lower()}@example.com", cumulative_score=0) for name in player_names]
     db_session.add_all(players)
     db_session.commit()
 

--- a/backend/tests/test_leaderboard_endpoint.py
+++ b/backend/tests/test_leaderboard_endpoint.py
@@ -1,0 +1,54 @@
+from datetime import date
+
+from litestar.testing import TestClient
+
+from app.config import create_app
+from app.schemas.orm import Match, Player, Round, Team, Tournament
+from app.services.db import db_instance
+
+
+def test_leaderboard_endpoint_includes_email(tmp_path):
+    original_url = db_instance._database_url
+    original_engine = db_instance._engine
+    original_session_local = db_instance._session_local
+
+    db_instance._database_url = f"sqlite:///{tmp_path / 'leaderboard.db'}"
+    db_instance._engine = None
+    db_instance._session_local = None
+
+    try:
+        app = create_app()
+
+        with TestClient(app) as client:
+            session_factory = db_instance.session_local
+            with session_factory() as session:
+                tournament = Tournament(name="Test Tournament", start_date=date.today())
+                session.add(tournament)
+
+                round_obj = Round(round_number=1, tournament_id=tournament.id)
+                session.add(round_obj)
+
+                match = Match(round_id=round_obj.id)
+                session.add(match)
+
+                team = Team(match_id=match.id, score=15)
+                session.add(team)
+
+                player = Player(name="Alice", email="alice@example.com")
+                session.add(player)
+                session.flush()
+
+                team.players.append(player)
+                session.commit()
+
+            response = client.get("/leaderboard/")
+            assert response.status_code == 200
+            payload = response.json()
+            assert payload
+            assert payload[0]["email"] == "alice@example.com"
+    finally:
+        if db_instance._engine is not None:
+            db_instance._engine.dispose()
+        db_instance._database_url = original_url
+        db_instance._engine = original_engine
+        db_instance._session_local = original_session_local


### PR DESCRIPTION
- route controllers through shared dependency providers and tidy session handling
- ensure leaderboard queries return player emails and keep registration atomic
- toughen tournament utilities and fixtures so schemas get valid names/emails
- add leaderboard regression test and isolate sqlite sessions for reliable runs